### PR TITLE
색상 팔레트 수정, 도안 변환 후 폼 자동으로 확장 추가

### DIFF
--- a/pixart/mainPage.cs
+++ b/pixart/mainPage.cs
@@ -22,7 +22,7 @@ namespace PixelColorling
         private Color selectedColor = Color.Transparent;
         private bool[,] isFilled;           // 셀이 색칠되었는지 여부
         private Color[,] filledColors;      // 셀에 실제 색칠한 색상
-
+        private float zoom = 1.0f; // 확대배율 추가
 
         public Coloring()
         {
@@ -86,10 +86,54 @@ namespace PixelColorling
                 }
             }
 
+            // 불러온 그림 크기에 따라 
+            panelCanvas.Size = new Size(wBlocks * blockSize, hBlocks * blockSize);
+
             // 4. 도안 그리기 요청 + 팔레트 생성
             panelCanvas.Invalidate();   // 다시 그리기
             CreateColorPalette();       // 색상 팔레트 생성
+
+            // 도안 패널 크기 맞추고
+            FitCanvas();
+            // 그에 맞춰 폼 전체 크기 맞추기
+            ResizeFormToFit();
         }
+
+        // panelCanvas 크기에 맞춰 Form 전체 크기 조정
+        private void FitCanvas()
+        {
+            // 도안 크기(블록수×blockSize) 만큼 panelCanvas 크기 맞추기
+            int wBlocks = originalImage.Width / blockSize;
+            int hBlocks = originalImage.Height / blockSize;
+
+            panelCanvas.Size = new Size(wBlocks * blockSize, hBlocks * blockSize);
+            panelCanvas.Invalidate();
+        }
+
+        // 폼을 도안 크기에 맞춰 크기 조정 (여유 공간 포함)
+        private void ResizeFormToFit()
+        {
+            // 클라이언트(내용) 영역 너비 = palette 폭 + canvas 폭
+            int clientW = panelLeft.Width + panelCanvas.Width;
+
+            // 클라이언트 높이는 두 영역 중 큰 쪽
+            int clientH = Math.Max(panelLeft.Height, panelCanvas.Height);
+
+            // 제목표시줄/테두리 보정값
+            int extraW = this.Width - this.ClientSize.Width;
+            int extraH = this.Height - this.ClientSize.Height;
+
+            // 여유 공간 (양쪽 각 20px씩)
+            const int marginW = 40;
+            const int marginH = 40;
+
+            // 폼 크기 설정
+            this.ClientSize = new Size(clientW + marginW, clientH + marginH);
+            this.Size = new Size(clientW + extraW + marginW,
+                                        clientH + extraH + marginH);
+        }
+
+
 
         //평균 색상 계산
         private Color GetAverageColor(int startX, int startY, int size)
@@ -108,33 +152,53 @@ namespace PixelColorling
 
             return Color.FromArgb(r / count, g / count, b / count);
         }
-        //팔레트 초기화 메서드
+
+        //팔레트 초기화 메서드.  등장 횟수별로 색상 팔레트 정렬
         private void CreateColorPalette()
         {
+            // 1) 색상 번호별 등장 횟수 카운트
+            var counts = new Dictionary<int, int>();
+            int rows = colorNumbers.GetLength(0);
+            int cols = colorNumbers.GetLength(1);
+            for (int y = 0; y < rows; y++)
+                for (int x = 0; x < cols; x++)
+                {
+                    int key = colorNumbers[y, x];
+                    if (counts.TryGetValue(key, out var existing))
+                        counts[key] = existing + 1;
+                    else
+                        counts[key] = 1;
+                }
+                    
+
+            // 2) 등장 횟수 내림차순 > 번호 순차 정렬
+            var sortedNums = counts
+              .OrderByDescending(kv => kv.Value)
+              .ThenBy(kv => kv.Key)
+              .Select(kv => kv.Key);
+
             panelPalette.Controls.Clear(); // 기존 팔레트 제거
 
             // 색상 → 번호 매핑 순서대로 정렬
             var sortedColors = colorMap.OrderBy(kv => kv.Value);
 
-            foreach (var kv in sortedColors)
+            // 4) 등장 빈도순으로 버튼 생성
+            foreach (int num in sortedNums)
             {
-                Color color = kv.Key;
-                int number = kv.Value;
+                // num 에 매핑된 색 찾아오기
+                Color c = colorMap.First(kv => kv.Value == num).Key;
 
-                Button colorButton = new Button
+                Button btn = new Button
                 {
-                    BackColor = color,
+                    BackColor = c,
+                    Text = num.ToString(),
                     Width = 40,
                     Height = 40,
                     Margin = new Padding(5),
-                    Text = number.ToString(),
-                    ForeColor = Color.Black,
-                    Tag = color
+                    Tag = c
                 };
-
-                colorButton.Click += ColorButton_Click;
-
-                panelPalette.Controls.Add(colorButton);
+                btn.Click += ColorButton_Click;
+                panelPalette.Controls.Add(btn);
             }
         }
 
@@ -184,64 +248,75 @@ namespace PixelColorling
 
         private void panelCanvas_Paint(object sender, PaintEventArgs e)
         {
-            // 도안이 없고, 이미지만 불러온 상태일 경우 원본 미리보기
+            var g = e.Graphics;
+            g.Clear(Color.White);
+
+         
+            // 도안이 없고 원본 이미지만 있을 때: 원본 미리보기
             if (blockColors == null && originalImage != null)
             {
-                // 비율 유지해서 그리기
+                // 비율 유지해서 원본 이미지를 패널 크기에 맞춰 그림
                 float scaleX = (float)panelCanvas.Width / originalImage.Width;
                 float scaleY = (float)panelCanvas.Height / originalImage.Height;
                 float scale = Math.Min(scaleX, scaleY);
 
-                int drawWidth = (int)(originalImage.Width * scale);
-                int drawHeight = (int)(originalImage.Height * scale);
+                int drawW = (int)(originalImage.Width * scale);
+                int drawH = (int)(originalImage.Height * scale);
+                int offsetX = (panelCanvas.Width - drawW) / 2;
+                int offsetY = (panelCanvas.Height - drawH) / 2;
 
-                int offsetX = (panelCanvas.Width - drawWidth) / 2;
-                int offsetY = (panelCanvas.Height - drawHeight) / 2;
-
-                e.Graphics.DrawImage(originalImage, new Rectangle(offsetX, offsetY, drawWidth, drawHeight));
-                return; // 더 이상 그릴 도안이 없으므로 여기서 종료
+                g.DrawImage(originalImage,
+                            new Rectangle(offsetX, offsetY, drawW, drawH));
+                return;
             }
 
-            if (blockColors == null) return;
+            if (blockColors == null)
+                return;  // 아무 것도 그릴 게 없으면 그냥 빠져나감
 
-            Graphics g = e.Graphics;
-            g.Clear(Color.White);
+            //  도안(번호 그리기) 
+            // 원하는 확대 배율(1.0 = 원래 크기, 2.0 = 두 배 등)
+            float zoom = 1.5f; // 화면 확대 비율
+            int renderSize = (int)(blockSize * zoom); // 실제 한 셀 크기
 
-            int hBlocks = blockColors.GetLength(0);
-            int wBlocks = blockColors.GetLength(1);
+            int rows = blockColors.GetLength(0);
+            int cols = blockColors.GetLength(1);
 
-            Font font = new Font("Arial", 8);
-
-            for (int y = 0; y < hBlocks; y++)
+            Font font = new Font("Arial", renderSize * 0.4f);
+            Pen pen = new Pen(Color.Gray);
+            
+            try
             {
-                for (int x = 0; x < wBlocks; x++)
+                for (int y = 0; y < rows; y++)
                 {
-                    Rectangle rect = new Rectangle(x * blockSize, y * blockSize, blockSize, blockSize);
-
-                    // 1. 색칠된 셀이면 색상 채우기
-                    if (isFilled != null && isFilled[y, x])
+                    for (int x = 0; x < cols; x++)
                     {
-                        using (SolidBrush brush = new SolidBrush(filledColors[y, x]))
+                        var rect = new Rectangle(
+                            x * renderSize,
+                            y * renderSize,
+                            renderSize,
+                            renderSize);
+
+                        // 색칠된 셀 채우기
+                        if (isFilled != null && isFilled[y, x])
                         {
-                            g.FillRectangle(brush, rect);
+                            using (var brush = new SolidBrush(filledColors[y, x]))
+                                g.FillRectangle(brush, rect);
                         }
-                    }
 
-                    // 2. 테두리 그리기
-                    g.DrawRectangle(Pens.Gray, rect);
+                        // 테두리
+                        g.DrawRectangle(pen, rect);
 
-                    // 3. 색칠 안 된 셀만 번호 표시
-                    if (!isFilled[y, x])
-                    {
+                        // 번호 그리기
                         string num = colorNumbers[y, x].ToString();
                         g.DrawString(num, font, Brushes.Black, rect.Location);
                     }
-
                 }
             }
-
-
-
+            finally
+            {
+                font.Dispose();
+                pen.Dispose();
+            }
         }
 
         private void btnSave_Click(object sender, EventArgs e)


### PR DESCRIPTION
1. 색상 추출 후 색상 팔레트에 나열할 때, 색상 번호순이 아닌 사진에 많이 등장하는 색상 순으로 나열하도록 수정
2. 큰 사진인 경우 도안 불러왔을 때 잘려보여서 전체가 보이도록 수정
2-1. 도안 불러왔을 때 기존의 폼 사이즈보다 도안의 크기가 더 크면 도안 크기에 맞춰 폼 크기 자동으로 확대
2-2. 난이도 중/상 선택시 픽셀의 크기가 너무 작아 각각의 번호가 겹쳐 보이는 현상을 픽셀 크기 확대하는 방향으로 수정중 
(난이도 중은 괜찮게 보이는데 난이도 상은 숫자가 너무 작아서 확인 불가능. 숫자 더 키우게 수정해야함) 